### PR TITLE
If / else semantic does not match comments in `add_to_saturate_quick`

### DIFF
--- a/src/ngram.rs
+++ b/src/ngram.rs
@@ -235,13 +235,13 @@ impl PartialReachable {
 
                 let discovered_ngram = discovered_context.get(dir, self.radius);
 
-                if self.reachable_ngrams[dir].contains(&discovered_ngram)
-                    && !self.reachable_local_contexts.contains(&discovered_context)
-                {
+                if self.reachable_ngrams[dir].contains(&discovered_ngram) {
                     // When the left half is known but the context as a whole is not, mark it as known
                     // and start over.
-                    self.reachable_local_contexts.insert(discovered_context);
-                    work_queue_local.push(discovered_context);
+                    if !self.reachable_local_contexts.contains(&discovered_context) {
+                        self.reachable_local_contexts.insert(discovered_context);
+                        work_queue_local.push(discovered_context);
+                    }
                 } else {
                     // Otherwise, remember that we are waiting on this gram, so that if it appears,
                     // we can revisit things.


### PR DESCRIPTION
if / else semantic does not match comments:

I'm not 100% sure about this one but it seems to me that the conditional block:

```rust
if self.reachable_ngrams[dir].contains(&discovered_ngram)
                    && !self.reachable_local_contexts.contains(&discovered_context) {
    // When the left half is known but the context as a whole is not, mark it as known
    // and start over.
    self.reachable_local_contexts.insert(discovered_context);
    work_queue_local.push(discovered_context);
} else {
    // Otherwise, remember that we are waiting on this gram, so that if it appears,
    // we can revisit things.
    work_queue_grams[dir]
        .entry(discovered_ngram)
        .or_default()
        .push(local_context);
}
```

Needs to be updated to:

```rust
if self.reachable_ngrams[dir].contains(&discovered_ngram) {
    // When the left half is known but the context as a whole is not, mark it as known
    // and start over.
    if !self.reachable_local_contexts.contains(&discovered_context) {
       self.reachable_local_contexts.insert(discovered_context);
       work_queue_local.push(discovered_context);
    }
} else {
    // Otherwise, remember that we are waiting on this gram, so that if it appears,
    // we can revisit things.
    work_queue_grams[dir]
        .entry(discovered_ngram)
        .or_default()
        .push(local_context);
}
```

Otherwise the `else` leg will also execute when we've already seen the `discovered_context` which does not seem like something we want?
